### PR TITLE
Fix: Responsive Footer Layout With Better Mobile Spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -426,6 +426,36 @@ footer {
     .categories {
         grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
     }
+    
+    footer {
+        padding: 30px 0 15px;
+    }
+    
+    .footer-content {
+        grid-template-columns: 1fr;
+        gap: 25px;
+        text-align: center;
+    }
+    
+    .footer-column h3 {
+        font-size: 1.1rem;
+        margin-bottom: 15px;
+    }
+    
+    .footer-column h3::after {
+        left: 50%;
+        transform: translateX(-50%);
+    }
+    
+    .footer-column ul li {
+        margin-bottom: 12px;
+    }
+    
+    .footer-bottom {
+        font-size: 0.8rem;
+        padding: 15px 10px 0;
+        line-height: 1.5;
+    }
 }
 
 @media (max-width: 480px) {
@@ -451,6 +481,32 @@ footer {
     
     .footer-content {
         grid-template-columns: 1fr;
+        gap: 20px;
+        padding: 0 10px;
+    }
+    
+    footer {
+        padding: 25px 0 10px;
+    }
+    
+    .footer-column h3 {
+        font-size: 1rem;
+        margin-bottom: 12px;
+    }
+    
+    .footer-column ul li {
+        margin-bottom: 8px;
+        font-size: 0.9rem;
+    }
+    
+    .footer-column ul li a:hover {
+        padding-left: 0;
+        color: var(--primary);
+    }
+    
+    .footer-bottom {
+        padding: 12px 5px 0;
+        margin: 15px 10px 0;
     }
 }
 


### PR DESCRIPTION
Enhanced the footer section to provide a better mobile-first responsive experience with improved stacking, spacing, and readability across all screen sizes.

Mobile-first design (≤768px):
Changed layout to single-column for cleaner stacking
Centered content for visual balance
Reduced padding & increased gaps for better spacing

Typography Optimizations:
Adjusted heading sizes (1.2rem → 1.1rem → 1rem) for tablets/mobiles
Improved list item spacing & readability

Visual Alignment:
Centered decorative underline under headings
Improved hover effects (color change instead of padding shift)

Small Screen (≤480px):
Compact padding & margins for tighter layout
Added horizontal padding for content alignment

Touch-Friendly Design:
Ensured adequate tap targets
Better line-height & spacing for mobile readability

Verified responsiveness on Chrome Dev Tools (mobile view)
Checked multiple breakpoints (desktop, tablet, mobile)

Would love suggestions if any